### PR TITLE
Preserve zero padding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ fn substitute_value(var: &Ident, splice: &Splice, body: TokenStream) -> TokenStr
                 _ => None,
             };
             if let Some(prefix) = prefix {
-                let concat = format!("{}{}", prefix, splice.int);
+                let concat = format!("{0}{1:02$}", prefix, splice.int, splice.width);
                 let ident = Ident::new(&concat, prefix.span());
                 tokens.splice(i..i + 3, iter::once(TokenTree::Ident(ident)));
                 i += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,10 +258,7 @@ fn expand_repetitions(
 
 impl Splice<'_> {
     fn literal(&self) -> Literal {
-        if self.suffix.is_empty() {
-            return Literal::u64_unsuffixed(self.int);
-        }
-        let repr = format!("{}{}", self.int, self.suffix);
+        let repr = format!("{0:02$}{1}", self.int, self.suffix, self.width);
         let tokens = repr.parse::<TokenStream>().unwrap();
         let mut iter = tokens.into_iter();
         let literal = match iter.next() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,17 +80,20 @@ struct Range {
     end: u64,
     inclusive: bool,
     suffix: String,
+    width: usize,
 }
 
 struct Value {
     int: u64,
     suffix: String,
+    width: usize,
     span: Span,
 }
 
 struct Splice<'a> {
     int: u64,
     suffix: &'a str,
+    width: usize,
 }
 
 impl<'a> IntoIterator for &'a Range {
@@ -99,10 +102,11 @@ impl<'a> IntoIterator for &'a Range {
 
     fn into_iter(self) -> Self::IntoIter {
         let suffix = &self.suffix;
+        let width = self.width;
         if self.inclusive {
-            Box::new((self.begin..=self.end).map(move |int| Splice { int, suffix }))
+            Box::new((self.begin..=self.end).map(move |int| Splice { int, suffix, width }))
         } else {
-            Box::new((self.begin..self.end).map(move |int| Splice { int, suffix }))
+            Box::new((self.begin..self.end).map(move |int| Splice { int, suffix, width }))
         }
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,6 +2,7 @@ use crate::{Range, Value};
 use proc_macro::token_stream::IntoIter as TokenIter;
 use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 use std::borrow::Borrow;
+use std::cmp;
 use std::fmt::Display;
 use std::iter::FromIterator;
 
@@ -158,6 +159,7 @@ pub(crate) fn validate_range(
         end: end.int,
         inclusive,
         suffix,
+        width: cmp::min(begin.width, end.width),
     })
 }
 
@@ -184,6 +186,12 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
     }
 
     let int = digits.parse::<u64>().ok()?;
+    let width = digits.len();
     let span = lit.span();
-    Some(Value { int, suffix, span })
+    Some(Value {
+        int,
+        suffix,
+        width,
+        span,
+    })
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -61,6 +61,17 @@ fn test_suffixed() {
     assert_eq!(n, "0u16");
 }
 
+#[test]
+fn test_padding() {
+    seq!(N in 098..=100 {
+        fn e#N() -> &'static str {
+            stringify!(N)
+        }
+    });
+    let strings = [e098(), e099(), e100()];
+    assert_eq!(strings, ["098", "099", "100"]);
+}
+
 pub mod test_enum {
     use seq_macro::seq;
 


### PR DESCRIPTION
For example:

```rust
seq!(N in 098..=100 {
    fn e#N() -> &'static str { stringify!(N) }
});
```

expands to:

```rust
fn e098() -> &'static str { "098" }
fn e099() -> &'static str { "099" }
fn e100() -> &'static str { "100" }
```