### PR TITLE
Allow byte literal and char literal as range endpoints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,12 +79,14 @@ struct Range {
     begin: u64,
     end: u64,
     inclusive: bool,
+    kind: Kind,
     suffix: String,
     width: usize,
 }
 
 struct Value {
     int: u64,
+    kind: Kind,
     suffix: String,
     width: usize,
     span: Span,
@@ -92,8 +94,16 @@ struct Value {
 
 struct Splice<'a> {
     int: u64,
+    kind: Kind,
     suffix: &'a str,
     width: usize,
+}
+
+#[derive(Copy, Clone)]
+enum Kind {
+    Int,
+    Byte,
+    Char,
 }
 
 impl<'a> IntoIterator for &'a Range {
@@ -101,9 +111,12 @@ impl<'a> IntoIterator for &'a Range {
     type IntoIter = Box<dyn Iterator<Item = Splice<'a>> + 'a>;
 
     fn into_iter(self) -> Self::IntoIter {
-        let suffix = &self.suffix;
-        let width = self.width;
-        let splice = move |int| Splice { int, suffix, width };
+        let splice = move |int| Splice {
+            int,
+            kind: self.kind,
+            suffix: &self.suffix,
+            width: self.width,
+        };
         if self.inclusive {
             Box::new((self.begin..=self.end).map(splice))
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,10 +118,24 @@ impl<'a> IntoIterator for &'a Range {
             suffix: &self.suffix,
             width: self.width,
         };
-        if self.inclusive {
-            Box::new((self.begin..=self.end).map(splice))
-        } else {
-            Box::new((self.begin..self.end).map(splice))
+        match self.kind {
+            Kind::Int | Kind::Byte => {
+                if self.inclusive {
+                    Box::new((self.begin..=self.end).map(splice))
+                } else {
+                    Box::new((self.begin..self.end).map(splice))
+                }
+            }
+            Kind::Char => {
+                let begin = char::from_u32(self.begin as u32).unwrap();
+                let end = char::from_u32(self.end as u32).unwrap();
+                let int = |ch| u64::from(u32::from(ch));
+                if self.inclusive {
+                    Box::new((begin..=end).map(int).map(splice))
+                } else {
+                    Box::new((begin..end).map(int).map(splice))
+                }
+            }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,7 +188,13 @@ fn substitute_value(var: &Ident, splice: &Splice, body: TokenStream) -> TokenStr
                 _ => None,
             };
             if let Some(prefix) = prefix {
-                let concat = format!("{0}{1:02$}", prefix, splice.int, splice.width);
+                let number = match splice.kind {
+                    Kind::Int => format!("{0:01$}", splice.int, splice.width),
+                    Kind::Byte | Kind::Char => {
+                        char::from_u32(splice.int as u32).unwrap().to_string()
+                    }
+                };
+                let concat = format!("{}{}", prefix, number);
                 let ident = Ident::new(&concat, prefix.span());
                 tokens.splice(i..i + 3, iter::once(TokenTree::Ident(ident)));
                 i += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@ struct Splice<'a> {
     width: usize,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 enum Kind {
     Int,
     Byte,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -144,6 +144,20 @@ pub(crate) fn validate_range(
     end: Value,
     inclusive: bool,
 ) -> Result<Range, SyntaxError> {
+    let kind = if begin.kind == end.kind {
+        begin.kind
+    } else {
+        let expected = match begin.kind {
+            Kind::Int => "integer",
+            Kind::Byte => "byte",
+            Kind::Char => "character",
+        };
+        return Err(SyntaxError {
+            message: format!("expected {} literal", expected),
+            span: end.span,
+        });
+    };
+
     let suffix = if begin.suffix.is_empty() {
         end.suffix
     } else if end.suffix.is_empty() || begin.suffix == end.suffix {
@@ -154,11 +168,12 @@ pub(crate) fn validate_range(
             span: end.span,
         });
     };
+
     Ok(Range {
         begin: begin.int,
         end: end.int,
         inclusive,
-        kind: begin.kind,
+        kind,
         suffix,
         width: cmp::min(begin.width, end.width),
     })

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -194,6 +194,16 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
         });
     }
 
+    if repr.starts_with('\'') && repr.ends_with('\'') && repr.chars().count() == 3 {
+        return Some(Value {
+            int: repr[1..].chars().next().unwrap() as u64,
+            kind: Kind::Char,
+            suffix: String::new(),
+            width: 0,
+            span,
+        });
+    }
+
     let mut digits = String::new();
     let mut suffix = String::new();
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::{Range, Value};
+use crate::{Kind, Range, Value};
 use proc_macro::token_stream::IntoIter as TokenIter;
 use proc_macro::{Delimiter, Group, Ident, Literal, Punct, Spacing, Span, TokenStream, TokenTree};
 use std::borrow::Borrow;
@@ -158,6 +158,7 @@ pub(crate) fn validate_range(
         begin: begin.int,
         end: end.int,
         inclusive,
+        kind: begin.kind,
         suffix,
         width: cmp::min(begin.width, end.width),
     })
@@ -186,10 +187,12 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
     }
 
     let int = digits.parse::<u64>().ok()?;
+    let kind = Kind::Int;
     let width = digits.len();
     let span = lit.span();
     Some(Value {
         int,
+        kind,
         suffix,
         width,
         span,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -180,8 +180,19 @@ pub(crate) fn validate_range(
 }
 
 fn parse_literal(lit: &Literal) -> Option<Value> {
+    let span = lit.span();
     let repr = lit.to_string();
     assert!(!repr.starts_with('_'));
+
+    if repr.starts_with("b'") && repr.ends_with('\'') && repr.len() == 4 {
+        return Some(Value {
+            int: repr.as_bytes()[2] as u64,
+            kind: Kind::Byte,
+            suffix: String::new(),
+            width: 0,
+            span,
+        });
+    }
 
     let mut digits = String::new();
     let mut suffix = String::new();
@@ -204,7 +215,6 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
     let int = digits.parse::<u64>().ok()?;
     let kind = Kind::Int;
     let width = digits.len();
-    let span = lit.span();
     Some(Value {
         int,
         kind,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -72,6 +72,28 @@ fn test_padding() {
     assert_eq!(strings, ["098", "099", "100"]);
 }
 
+#[test]
+fn test_byte() {
+    seq!(c in b'x'..=b'z' {
+        fn get_#c() -> u8 {
+            c
+        }
+    });
+    let bytes = [get_x(), get_y(), get_z()];
+    assert_eq!(bytes, *b"xyz");
+}
+
+#[test]
+fn test_char() {
+    seq!(ch in 'x'..='z' {
+        fn get_#ch() -> char {
+            ch
+        }
+    });
+    let chars = [get_x(), get_y(), get_z()];
+    assert_eq!(chars, ['x', 'y', 'z']);
+}
+
 pub mod test_enum {
     use seq_macro::seq;
 

--- a/tests/ui/kind-mismatch.rs
+++ b/tests/ui/kind-mismatch.rs
@@ -1,0 +1,5 @@
+use seq_macro::seq;
+
+seq!(N in 'a'..b'z' {});
+
+fn main() {}

--- a/tests/ui/kind-mismatch.stderr
+++ b/tests/ui/kind-mismatch.stderr
@@ -1,0 +1,5 @@
+error: expected character literal
+ --> $DIR/kind-mismatch.rs:3:16
+  |
+3 | seq!(N in 'a'..b'z' {});
+  |                ^^^^


### PR DESCRIPTION
```rust
seq!(ch in 'x'..='z' {
    fn get_#ch() -> char {
        ch
    }
});

let chars = [get_x(), get_y(), get_z()];
assert_eq!(chars, ['x', 'y', 'z']);
```