### PR TITLE
Preserve binary, octal, lower hex, upper hex representation of literals

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,13 @@ fn substitute_value(var: &Ident, splice: &Splice, body: TokenStream) -> TokenStr
             };
             if let Some(prefix) = prefix {
                 let number = match splice.kind {
-                    Kind::Int => format!("{0:01$}", splice.int, splice.width),
+                    Kind::Int => match splice.radix {
+                        2 => format!("{0:01$b}", splice.int, splice.width),
+                        8 => format!("{0:01$o}", splice.int, splice.width),
+                        10 => format!("{0:01$}", splice.int, splice.width),
+                        16 => format!("{0:01$x}", splice.int, splice.width),
+                        _ => unreachable!(),
+                    },
                     Kind::Byte | Kind::Char => {
                         char::from_u32(splice.int as u32).unwrap().to_string()
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,8 @@ enum Radix {
     Binary,
     Octal,
     Decimal,
-    Hex,
+    LowerHex,
+    UpperHex,
 }
 
 impl<'a> IntoIterator for &'a Range {
@@ -219,7 +220,8 @@ fn substitute_value(var: &Ident, splice: &Splice, body: TokenStream) -> TokenStr
                         Radix::Binary => format!("{0:01$b}", splice.int, splice.width),
                         Radix::Octal => format!("{0:01$o}", splice.int, splice.width),
                         Radix::Decimal => format!("{0:01$}", splice.int, splice.width),
-                        Radix::Hex => format!("{0:01$x}", splice.int, splice.width),
+                        Radix::LowerHex => format!("{0:01$x}", splice.int, splice.width),
+                        Radix::UpperHex => format!("{0:01$X}", splice.int, splice.width),
                     },
                     Kind::Byte | Kind::Char => {
                         char::from_u32(splice.int as u32).unwrap().to_string()
@@ -316,7 +318,8 @@ impl Splice<'_> {
                     Radix::Binary => format!("0b{0:02$b}{1}", self.int, self.suffix, self.width),
                     Radix::Octal => format!("0o{0:02$o}{1}", self.int, self.suffix, self.width),
                     Radix::Decimal => format!("{0:02$}{1}", self.int, self.suffix, self.width),
-                    Radix::Hex => format!("0x{0:02$x}{1}", self.int, self.suffix, self.width),
+                    Radix::LowerHex => format!("0x{0:02$x}{1}", self.int, self.suffix, self.width),
+                    Radix::UpperHex => format!("0x{0:02$X}{1}", self.int, self.suffix, self.width),
                 };
                 let tokens = repr.parse::<TokenStream>().unwrap();
                 let mut iter = tokens.into_iter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ struct Value {
     kind: Kind,
     suffix: String,
     width: usize,
+    radix: u32,
     span: Span,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ struct Range {
     kind: Kind,
     suffix: String,
     width: usize,
+    radix: u32,
 }
 
 struct Value {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -169,6 +169,22 @@ pub(crate) fn validate_range(
         });
     };
 
+    let radix = if begin.radix == end.radix {
+        begin.radix
+    } else {
+        let expected = match begin.radix {
+            2 => "binary",
+            8 => "octal",
+            10 => "base 10",
+            16 => "hexadecimal",
+            _ => unreachable!(),
+        };
+        return Err(SyntaxError {
+            message: format!("expected {} literal", expected),
+            span: end.span,
+        });
+    };
+
     Ok(Range {
         begin: begin.int,
         end: end.int,
@@ -176,6 +192,7 @@ pub(crate) fn validate_range(
         kind,
         suffix,
         width: cmp::min(begin.width, end.width),
+        radix,
     })
 }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -176,7 +176,7 @@ pub(crate) fn validate_range(
             Radix::Binary => "binary",
             Radix::Octal => "octal",
             Radix::Decimal => "base 10",
-            Radix::Hex => "hexadecimal",
+            Radix::LowerHex | Radix::UpperHex => "hexadecimal",
         };
         return Err(SyntaxError {
             message: format!("expected {} literal", expected),
@@ -227,7 +227,9 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
     } else if repr.starts_with("0o") {
         (Radix::Octal, 8)
     } else if repr.starts_with("0x") {
-        (Radix::Hex, 16)
+        (Radix::LowerHex, 16)
+    } else if repr.starts_with("0X") {
+        (Radix::UpperHex, 16)
     } else {
         (Radix::Decimal, 10)
     };

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -246,6 +246,7 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
         match ch {
             '_' => continue,
             '0'..='9' => digits.push(ch),
+            'a'..='f' | 'A'..='F' if radix_n == 16 => digits.push(ch),
             '.' => return None,
             _ => {
                 if digits.is_empty() {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -190,6 +190,7 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
             kind: Kind::Byte,
             suffix: String::new(),
             width: 0,
+            radix: 10,
             span,
         });
     }
@@ -200,14 +201,30 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
             kind: Kind::Char,
             suffix: String::new(),
             width: 0,
+            radix: 0,
             span,
         });
     }
 
+    let radix = if repr.starts_with("0b") {
+        2
+    } else if repr.starts_with("0o") {
+        8
+    } else if repr.starts_with("0x") {
+        16
+    } else {
+        10
+    };
+
+    let mut iter = repr.char_indices();
     let mut digits = String::new();
     let mut suffix = String::new();
 
-    for (i, ch) in repr.char_indices() {
+    if radix != 10 {
+        let _ = iter.nth(1);
+    }
+
+    for (i, ch) in iter {
         match ch {
             '_' => continue,
             '0'..='9' => digits.push(ch),
@@ -223,7 +240,7 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
         }
     }
 
-    let int = digits.parse::<u64>().ok()?;
+    let int = u64::from_str_radix(&digits, radix).ok()?;
     let kind = Kind::Int;
     let width = digits.len();
     Some(Value {
@@ -231,6 +248,7 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
         kind,
         suffix,
         width,
+        radix,
         span,
     })
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -171,6 +171,10 @@ pub(crate) fn validate_range(
 
     let radix = if begin.radix == end.radix {
         begin.radix
+    } else if begin.radix == Radix::LowerHex && end.radix == Radix::UpperHex
+        || begin.radix == Radix::UpperHex && end.radix == Radix::LowerHex
+    {
+        Radix::UpperHex
     } else {
         let expected = match begin.radix {
             Radix::Binary => "binary",
@@ -222,7 +226,7 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
         });
     }
 
-    let (radix, radix_n) = if repr.starts_with("0b") {
+    let (mut radix, radix_n) = if repr.starts_with("0b") {
         (Radix::Binary, 2)
     } else if repr.starts_with("0o") {
         (Radix::Octal, 8)
@@ -246,6 +250,10 @@ fn parse_literal(lit: &Literal) -> Option<Value> {
         match ch {
             '_' => continue,
             '0'..='9' => digits.push(ch),
+            'A'..='F' if radix == Radix::LowerHex => {
+                digits.push(ch);
+                radix = Radix::UpperHex;
+            }
             'a'..='f' | 'A'..='F' if radix_n == 16 => digits.push(ch),
             '.' => return None,
             _ => {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -94,6 +94,44 @@ fn test_char() {
     assert_eq!(chars, ['x', 'y', 'z']);
 }
 
+#[test]
+fn test_binary() {
+    let s = seq!(B in 0b00..=0b11 { stringify!(#(B)*) });
+    let expected = "0b00 0b01 0b10 0b11";
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn test_octal() {
+    let s = seq!(O in 0o6..0o12 { stringify!(#(O)*) });
+    let expected = "0o6 0o7 0o10 0o11";
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn test_hex() {
+    let s = seq!(X in 0x08..0x0c { stringify!(#(X)*) });
+    let expected = "0x08 0x09 0x0a 0x0b";
+    assert_eq!(expected, s);
+
+    let s = seq!(X in 0x08..0x0C { stringify!(#(X)*) });
+    let expected = "0x08 0x09 0x0A 0x0B";
+    assert_eq!(expected, s);
+
+    let s = seq!(X in 0X09..0X10 { stringify!(#(X)*) });
+    let expected = "0x09 0x0A 0x0B 0x0C 0x0D 0x0E 0x0F";
+    assert_eq!(expected, s);
+}
+
+#[test]
+fn test_radix_concat() {
+    seq!(B in 0b011..0b101 { struct S#B; });
+    seq!(O in 0o007..0o011 { struct S#O; });
+    seq!(X in 0x00a..0x00c { struct S#X; });
+    seq!(X in 0x00C..0x00E { struct S#X; });
+    let _ = (S011, S100, S007, S010, S00a, S00b, S00C, S00D);
+}
+
 pub mod test_enum {
     use seq_macro::seq;
 


### PR DESCRIPTION
```rust
seq!(X in 0x009..=0x00B {
    struct Struct#X;
});
```

expands to:

```rust
struct Struct009;
struct Struct00A;
struct Struct00B;
```