### PR TITLE
Change the `#` infix to `~`, to support Rust 2021 edition.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ seq!(N in 64..=127 {
     enum Demo {
         // Expands to Variant64, Variant65, ...
         #(
-            Variant#N,
+            Variant~N,
         )*
     }
 });
@@ -74,7 +74,7 @@ use seq_macro::seq;
 
 seq!(P in 0x000..=0x00F {
     // expands to structs Pin000, ..., Pin009, Pin00A, ..., Pin00F
-    struct Pin#P;
+    struct Pin~P;
 });
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //!     enum Demo {
 //!         // Expands to Variant64, Variant65, ...
 //!         ##(
-//!             Variant#N,
+//!             Variant~N,
 //!         )*
 //!     }
 //! });
@@ -69,7 +69,7 @@
 //!
 //! seq!(P in 0x000..=0x00F {
 //!     // expands to structs Pin000, ..., Pin009, Pin00A, ..., Pin00F
-//!     struct Pin#P;
+//!     struct Pin~P;
 //! });
 //! ```
 
@@ -224,11 +224,11 @@ fn substitute_value(var: &Ident, splice: &Splice, body: TokenStream) -> TokenStr
             continue;
         }
 
-        // Substitute our variable concatenated onto some prefix, `Prefix#N`.
+        // Substitute our variable concatenated onto some prefix, `Prefix~N`.
         if i + 3 <= tokens.len() {
             let prefix = match &tokens[i..i + 3] {
-                [first, TokenTree::Punct(pound), TokenTree::Ident(ident)]
-                    if pound.as_char() == '#' && ident.to_string() == var.to_string() =>
+                [first, TokenTree::Punct(tilde), TokenTree::Ident(ident)]
+                    if tilde.as_char() == '~' && ident.to_string() == var.to_string() =>
                 {
                     match first {
                         TokenTree::Ident(ident) => Some(ident.clone()),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -22,7 +22,7 @@ fn test_nothing() {
 #[test]
 fn test_fn() {
     seq!(N in 1..4 {
-        fn f#N () -> u64 {
+        fn f~N () -> u64 {
             N * 2
         }
     });
@@ -66,7 +66,7 @@ fn test_suffixed() {
 #[test]
 fn test_padding() {
     seq!(N in 098..=100 {
-        fn e#N() -> &'static str {
+        fn e~N() -> &'static str {
             stringify!(N)
         }
     });
@@ -77,7 +77,7 @@ fn test_padding() {
 #[test]
 fn test_byte() {
     seq!(c in b'x'..=b'z' {
-        fn get_#c() -> u8 {
+        fn get_~c() -> u8 {
             c
         }
     });
@@ -88,7 +88,7 @@ fn test_byte() {
 #[test]
 fn test_char() {
     seq!(ch in 'x'..='z' {
-        fn get_#ch() -> char {
+        fn get_~ch() -> char {
             ch
         }
     });
@@ -127,10 +127,10 @@ fn test_hex() {
 
 #[test]
 fn test_radix_concat() {
-    seq!(B in 0b011..0b101 { struct S#B; });
-    seq!(O in 0o007..0o011 { struct S#O; });
-    seq!(X in 0x00a..0x00c { struct S#X; });
-    seq!(X in 0x00C..0x00E { struct S#X; });
+    seq!(B in 0b011..0b101 { struct S~B; });
+    seq!(O in 0o007..0o011 { struct S~O; });
+    seq!(X in 0x00a..0x00c { struct S~X; });
+    seq!(X in 0x00C..0x00E { struct S~X; });
     let _ = (S011, S100, S007, S010, S00a, S00b, S00C, S00D);
 }
 
@@ -139,7 +139,7 @@ fn test_ident() {
     macro_rules! create {
         ($prefix:ident) => {
             seq!(N in 0..1 {
-                struct $prefix#N;
+                struct $prefix~N;
             });
         };
     }
@@ -154,7 +154,7 @@ pub mod test_enum {
         #[derive(Copy, Clone, PartialEq, Debug)]
         pub enum Interrupt {
             #(
-                Irq#N,
+                Irq~N,
             )*
         }
     });
@@ -173,7 +173,7 @@ pub mod test_inclusive {
     seq!(N in 16..=20 {
         pub enum E {
             #(
-                Variant#N,
+                Variant~N,
             )*
         }
     });

--- a/tests/ui/ident-span.rs
+++ b/tests/ui/ident-span.rs
@@ -2,6 +2,6 @@ use seq_macro::seq;
 
 seq!(N in 0..1 {
     fn main() {
-        let _ = Missing#N;
+        let _ = Missing~N;
     }
 });

--- a/tests/ui/ident-span.stderr
+++ b/tests/ui/ident-span.stderr
@@ -1,5 +1,5 @@
 error[E0425]: cannot find value `Missing0` in this scope
  --> tests/ui/ident-span.rs:5:17
   |
-5 |         let _ = Missing#N;
+5 |         let _ = Missing~N;
   |                 ^^^^^^^ not found in this scope


### PR DESCRIPTION
Fixes #11, but breaks existing code using this macro.